### PR TITLE
Added validation for virtualenv before running Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ ifeq ($(shell which docker-compose),)
   $(error docker-compose is not installed, please install it before using project)
 endif
 
+ifeq ($(shell which virtualenv),)
+  $(error virtualenv is not installed, please install it before using project)
+endif
+
 # check variables coherence
 ifeq ($(filter $(OS_CONTAINER), ubuntu centos),)
   $(error variable OS_CONTAINER is bad defined '$(OS_CONTAINER)', do make <option> <target> ... OS_CONTAINER=<os> possible values: ubuntu centos)


### PR DESCRIPTION
When I ran this, I did not have virtualenv installed. The make file attempted to run which caused the process to fail after the Makefile had removed necessary files, requiring me to delete the folder, re-clone, and re-execute the make command.