### PR TITLE
fix: use docker compose instead of docker-compose

### DIFF
--- a/.ci/check-version.sh
+++ b/.ci/check-version.sh
@@ -34,7 +34,7 @@ echo "=== docker version ==="
 docker --version
 
 echo "=== docker-compose version ==="
-docker-compose --version
+docker compose version
 
 echo "=== docker info ==="
 docker info

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,6 @@ ifeq ($(shell which docker),)
   $(error docker is not installed, please install it before using project)
 endif
 
-ifeq ($(shell which docker-compose),)
-  $(error docker-compose is not installed, please install it before using project)
-endif
-
 # check variables coherence
 ifeq ($(filter $(OS_CONTAINER), ubuntu centos),)
   $(error variable OS_CONTAINER is bad defined '$(OS_CONTAINER)', do make <option> <target> ... OS_CONTAINER=<os> possible values: ubuntu centos)

--- a/script/build.sh
+++ b/script/build.sh
@@ -12,13 +12,13 @@ n_processes=$(grep -c ^processor /proc/cpuinfo)
 echo "max of processes:  ${n_processes}"
 
 # Build each service in parallel instead of sequentially
-services=$(docker-compose config --services)
+services=$(docker compose config --services)
 for service in ${services}; do
   while [[ $(jobs -r | wc -l) -gt ${n_processes} ]]; do
     :
   done
   echo "=== build docker service '${service}' as image ==="
-  docker-compose -f docker-compose.yml build "${service}" &
+  docker compose -f docker-compose.yml build "${service}" &
 done
 
 wait

--- a/script/clean.sh
+++ b/script/clean.sh
@@ -31,7 +31,7 @@ if [[ ! "${answer}" =~ ^(Y|y|yes|)$ ]]; then
 fi
 echo "=== Remove services as docker container ==="
 if [[ -f docker-compose.yml ]]; then
-  docker-compose -f docker-compose.yml rm --force
+  docker compose -f docker-compose.yml rm --force
 else
   >&2 echo "WARN: Can't remove cluster of containers, no docker-compose.yml file!"
 fi

--- a/script/inspect.sh
+++ b/script/inspect.sh
@@ -5,9 +5,9 @@
 # Inspect docker architecture for kerberos cluster.
 
 
-services=$(docker-compose -f docker-compose.yml config --services)
+services=$(docker compose -f docker-compose.yml config --services)
 for service in ${services}; do
   echo "=== Inspect service: ${service} ==="
-  container_id=$(docker-compose -f docker-compose.yml ps -q ${service})
+  container_id=$(docker compose -f docker-compose.yml ps -q ${service})
   docker inspect "${container_id}"
 done

--- a/script/start.sh
+++ b/script/start.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")"
 cd ..
 
 if [[ -f docker-compose.yml ]]; then
-  docker-compose -f docker-compose.yml start
+  docker compose -f docker-compose.yml start
 else
   >&2 echo "WARN: Can't start cluster of containers, no docker-compose.yml file!"
 fi

--- a/script/status.sh
+++ b/script/status.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")"
 cd ..
 
 if [[ -f docker-compose.yml ]]; then
-  docker-compose -f docker-compose.yml ps
+  docker compose -f docker-compose.yml ps
 else
   >&2 echo "WARN: Can't stop cluster of containers, no docker-compose.yml file!"
 fi

--- a/script/stop.sh
+++ b/script/stop.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")"
 cd ..
 
 if [[ -f docker-compose.yml ]]; then
-  docker-compose -f docker-compose.yml stop
+  docker compose -f docker-compose.yml stop
 else
   >&2 echo "WARN: Can't stop cluster of containers, no docker-compose.yml file!"
 fi


### PR DESCRIPTION
docker-compose is to be replaced by docker compose as far as I am aware.
On my system I couldn't install docker-compose because of dnf package dependancies not resolvable.